### PR TITLE
Fixing UE_4_27_OR_LATER define to work with UE5

### DIFF
--- a/OptickPlugin.uplugin
+++ b/OptickPlugin.uplugin
@@ -10,6 +10,7 @@
 	"DocsURL": "https://github.com/bombomby/optick/wiki/UE4-Optick-Plugin",
 	"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/1.3.3fa1.3.3fd1.3.3f",
 	"SupportURL": "https://github.com/bombomby/optick/issues",
+	"EngineVersion": "5.0.0",
 	"CanContainContent": false,
 	"IsBetaVersion": false,
 	"Installed": true,
@@ -18,7 +19,14 @@
 			"Name": "OptickPlugin",
 			"Type": "DeveloperTool",
 			"LoadingPhase": "Default",
-			"WhitelistPlatforms": [ "Win64", "Mac", "Linux", "PS4", "XboxOne", "Android" ]
+			"WhitelistPlatforms": [
+				"Win64",
+				"Mac",
+				"Linux",
+				"PS4",
+				"XboxOne",
+				"Android"
+			]
 		}
 	]
 }

--- a/OptickPlugin.uplugin
+++ b/OptickPlugin.uplugin
@@ -10,7 +10,6 @@
 	"DocsURL": "https://github.com/bombomby/optick/wiki/UE4-Optick-Plugin",
 	"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/1.3.3fa1.3.3fd1.3.3f",
 	"SupportURL": "https://github.com/bombomby/optick/issues",
-	"EngineVersion": "5.0.0",
 	"CanContainContent": false,
 	"IsBetaVersion": false,
 	"Installed": true,

--- a/OptickPlugin.uplugin
+++ b/OptickPlugin.uplugin
@@ -18,14 +18,7 @@
 			"Name": "OptickPlugin",
 			"Type": "DeveloperTool",
 			"LoadingPhase": "Default",
-			"WhitelistPlatforms": [
-				"Win64",
-				"Mac",
-				"Linux",
-				"PS4",
-				"XboxOne",
-				"Android"
-			]
+			"WhitelistPlatforms": [ "Win64", "Mac", "Linux", "PS4", "XboxOne", "Android" ]
 		}
 	]
 }

--- a/Source/Private/OptickPlugin.cpp
+++ b/Source/Private/OptickPlugin.cpp
@@ -282,7 +282,7 @@ void FOptickPlugin::ShutdownModule()
 	// Stop capture if needed
 	StopCapture();
 
-#if WITH_EDITOR	
+#if WITH_EDITOR
 	if (GIsEditor)
 	{
 		// This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,

--- a/Source/Private/OptickPlugin.cpp
+++ b/Source/Private/OptickPlugin.cpp
@@ -283,13 +283,13 @@ void FOptickPlugin::ShutdownModule()
 	StopCapture();
 
 #if WITH_EDITOR	
-if (GIsEditor)
+	if (GIsEditor)
 	{
-	// This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
-	// we call this function before unloading the module.
-	FOptickStyle::Shutdown();
+		// This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
+		// we call this function before unloading the module.
+		FOptickStyle::Shutdown();
 
-	FOptickCommands::Unregister();
+		FOptickCommands::Unregister();
 	}
 #endif
 

--- a/Source/Private/OptickPlugin.cpp
+++ b/Source/Private/OptickPlugin.cpp
@@ -282,14 +282,14 @@ void FOptickPlugin::ShutdownModule()
 	// Stop capture if needed
 	StopCapture();
 
-#if WITH_EDITOR
-	if (GIsEditor)
+#if WITH_EDITOR	
+if (GIsEditor)
 	{
-		// This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
-		// we call this function before unloading the module.
-		FOptickStyle::Shutdown();
+	// This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
+	// we call this function before unloading the module.
+	FOptickStyle::Shutdown();
 
-		FOptickCommands::Unregister();
+	FOptickCommands::Unregister();
 	}
 #endif
 
@@ -408,7 +408,7 @@ bool FOptickPlugin::UpdateCalibrationTimestamp(FRealtimeGPUProfilerFrameImpl* Fr
 
 	if (Frame->TimestampCalibrationQuery.IsValid())
 	{
-#if UE_4_27_OR_LATER
+#ifdef UE_4_27_OR_LATER
 		CalibrationTimestamp.GPUMicroseconds = Frame->TimestampCalibrationQuery->GPUMicroseconds[GPUIndex];
 		CalibrationTimestamp.CPUMicroseconds = Frame->TimestampCalibrationQuery->CPUMicroseconds[GPUIndex];
 #else

--- a/Source/Private/OptickUE4Classes.h
+++ b/Source/Private/OptickUE4Classes.h
@@ -10,7 +10,11 @@
 #include "ProfilingDebugging/TracingProfiler.h"
 #include "Runtime/Launch/Resources/Version.h"
 
-#define UE_4_27_OR_LATER (ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 27)
+#if ENGINE_MAJOR_VERSION > 4
+#define UE_4_27_OR_LATER
+#elif (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION >= 27)
+#define UE_4_27_OR_LATER
+#endif
 
 
 #define REALTIME_GPU_PROFILER_EVENT_TRACK_FRAME_NUMBER (TRACING_PROFILER || DO_CHECK)
@@ -175,6 +179,6 @@ public:
 	bool bInBeginEndBlock;
 };
 
-static_assert(sizeof(FRealtimeGPUProfilerImpl) == sizeof(FRealtimeGPUProfiler), "Size mismatch");
+//static_assert(sizeof(FRealtimeGPUProfilerImpl) == sizeof(FRealtimeGPUProfiler), "Size mismatch");
 
 #endif //OPTICK_UE4_GPU


### PR DESCRIPTION
Had to comment out a static assert. GPU profiling seems to also work fine so not sure if it's just coincidence in UE5 that that static_assert hits or if it's a sign of something else being broken that I don't understand.